### PR TITLE
Update smithsnmp-0.8-2.rockspec to support RHEL

### DIFF
--- a/smithsnmp-0.8-2.rockspec
+++ b/smithsnmp-0.8-2.rockspec
@@ -31,6 +31,7 @@ build = {
                                 "m",
                                 "dl",
                                 "lua5.1",
+                                "lua-5.1",
                         },
                         sources = {
                                 "3rd/crypto/openssl_aes.c",


### PR DESCRIPTION
In RHEL, we notice the lua5.1 library is installed at **_/usr/lib64/liblua-5.1.so_**. This can only be found by the rockspec file when the library is given as "lua-5.1" instead of "lua5.1". Added both.